### PR TITLE
Remove env variable for default slurm account

### DIFF
--- a/jz/envs/README.md
+++ b/jz/envs/README.md
@@ -38,10 +38,6 @@ export CONDA_ENVS_PATH=$six_ALL_CCFRWORK/conda
 # share dirs/files with the group
 umask 0007
 
-export SBATCH_ACCOUNT=six@gpu
-export SLURM_ACCOUNT=six@gpu
-export SALLOC_ACCOUNT=six@gpu
-
 # specific caches
 export TRANSFORMERS_CACHE=$six_ALL_CCFRWORK/models
 export HF_DATASETS_CACHE=$six_ALL_CCFRWORK/datasets

--- a/jz/envs/start-prod
+++ b/jz/envs/start-prod
@@ -26,13 +26,6 @@ source $six_ALL_CCFRWORK/envs/.bash-git-prompt/gitprompt.sh
 
 # SLURM / Account specific settings
 
-# six@gpu is the bigscience account
-# ajs@gpu is an older long-term general access account
-
-export SBATCH_ACCOUNT=six@gpu
-export SLURM_ACCOUNT=six@gpu
-export SALLOC_ACCOUNT=six@gpu
-
 # specific caches
 
 export TRANSFORMERS_CACHE=$six_ALL_CCFRWORK/models

--- a/jz/envs/start-user
+++ b/jz/envs/start-user
@@ -22,11 +22,6 @@ source $six_ALL_CCFRWORK/envs/.bash-git-prompt/gitprompt.sh
 
 # SLURM / Account specific settings
 
-# six@gpu is the bigscience account
-
-export SBATCH_ACCOUNT=six@gpu
-export SLURM_ACCOUNT=six@gpu
-
 # specific caches
 
 export TRANSFORMERS_CACHE=$six_ALL_CCFRWORK/models

--- a/jz/slurm/README.md
+++ b/jz/slurm/README.md
@@ -20,8 +20,6 @@ CPU-only nodes: `--account=six@cpu`
 - `-p cpu_p1`:  up to 100h: this is the default partition for `--account=six@cpu`
 only 20h by default, add `--qos=qos_cpu-t4` to use 100h
 
-**Important: Currently to launch jobs on `-p cpu_p1` one must explicitly pass `--account=six@cpu` on the command line `sbatch --account=six@cpu ...` as it ignores the `#SBATCH --account=six@cpu` listing in the slurm script.**
-
 **Additionally, having `#SBATCH --gres=gpu:0` in a slurm file forces gpu allocations as well, ignoring the account specification. So remove those**
 
 The following CPU-only partitions time on which isn't deducted from allocation:


### PR DESCRIPTION
Default slurm account prevented us from using cpu slurm account in script, and we had to specify them everytime we ran cpu work.

To fix that, we remove default account and force all users to specify the account themselves in slurm scripts.