### PR TITLE
WIP: add oscar slurm script for preprocess_data_dist

### DIFF
--- a/data/oscar/oscar-jsonl-to-meg-gpt2-dist.slurm
+++ b/data/oscar/oscar-jsonl-to-meg-gpt2-dist.slurm
@@ -26,13 +26,13 @@ output=$six_ALL_CCFRSCRATCH/datasets/oscar-small/meg-gpt2-dist
 #
 # cd $six_ALL_CCFRWORK/code/megatron-lm
 # <set CMD just as below>
-# srun -n 320 -N 8 $CMD --mpi4py
+# srun -n 320 -N 8 python $CMD --mpi4py
 
 ##########################
 # Setup to run preprocess_data_dist as a torch.distributed job
 ##########################
 
-# I use a line like the following.  Perhaps easier to reas if this works for you?
+# I use a line like the following.  Perhaps easier to read if this works for you?
 #MASTER_ADDR=`scontrol show hostname ${SLURM_NODELIST} | head -n1`
 MASTER_ADDR=`perl -le '$_=$ENV{"SLURM_JOB_NODELIST"}; s/,.*//; s/-.*//; s/\[//; print'`
 MASTER_PORT=6000

--- a/data/oscar/oscar-jsonl-to-meg-gpt2-dist.slurm
+++ b/data/oscar/oscar-jsonl-to-meg-gpt2-dist.slurm
@@ -33,7 +33,7 @@ output=$six_ALL_CCFRSCRATCH/datasets/oscar-small/meg-gpt2-dist
 ##########################
 
 # I use a line like the following.  Perhaps easier to read if this works for you?
-#MASTER_ADDR=`scontrol show hostname ${SLURM_NODELIST} | head -n1`
+#MASTER_ADDR=`scontrol show hostname | head -1`
 MASTER_ADDR=`perl -le '$_=$ENV{"SLURM_JOB_NODELIST"}; s/,.*//; s/-.*//; s/\[//; print'`
 MASTER_PORT=6000
 

--- a/data/oscar/oscar-jsonl-to-meg-gpt2-dist.slurm
+++ b/data/oscar/oscar-jsonl-to-meg-gpt2-dist.slurm
@@ -1,0 +1,62 @@
+#!/bin/bash
+#SBATCH --job-name=oscar-jsonl-to-meg-gpt2-dist # job name
+#SBATCH --ntasks=320                 # number of MP tasks
+#SBATCH --nodes=8
+#SBATCH --cpus-per-task=1            # number of cores per tasks
+#SBATCH --hint=nomultithread         # we get physical cores not logical
+#SBATCH --time=8:00:00               # maximum execution time (HH:MM:SS)
+#SBATCH --output=%x-%j.out          # output file name
+#SBATCH --account=six@cpu
+#SBATCH --partition=cpu_p1
+
+set -x -e
+
+source $six_ALL_CCFRWORK/start-prod
+
+input=$six_ALL_CCFRSCRATCH/datasets/oscar-small/oscar-en-shuffled-p1.jsonl
+output=$six_ALL_CCFRSCRATCH/datasets/oscar-small/meg-gpt2-dist
+
+##########################
+# Setup to run preprocess_data_dist as an mpi4py job
+##########################
+
+# Note: if mpi4py works with the system MPI,
+# and if srun is configured to launch system MPI jobs,
+# then I think the following should be sufficient:
+#
+# cd $six_ALL_CCFRWORK/code/megatron-lm
+# <set CMD just as below>
+# srun -n 320 -N 8 $CMD --mpi4py
+
+##########################
+# Setup to run preprocess_data_dist as a torch.distributed job
+##########################
+
+# I use a line like the following.  Perhaps easier to reas if this works for you?
+#MASTER_ADDR=`scontrol show hostname ${SLURM_NODELIST} | head -n1`
+MASTER_ADDR=`perl -le '$_=$ENV{"SLURM_JOB_NODELIST"}; s/,.*//; s/-.*//; s/\[//; print'`
+MASTER_PORT=6000
+
+NNODES=$SLURM_NNODES
+
+export LAUNCHER="python -u -m torch.distributed.launch \
+    --nproc_per_node 40 \
+    --nnodes $NNODES \
+    --master_addr $MASTER_ADDR \
+    --master_port $MASTER_PORT \
+    "
+
+cd $six_ALL_CCFRWORK/code/megatron-lm
+CMD="tools/preprocess_data_dist.py \
+       --input $input \
+       --output-prefix $output \
+       --vocab data/gpt2-vocab.json \
+       --merge-file data/gpt2-merges.txt \
+       --dataset-impl mmap \
+       --tokenizer-type GPT2BPETokenizer \
+       --append-eod
+       "
+
+srun --jobid $SLURM_JOBID bash -c '$LAUNCHER --node_rank $SLURM_PROCID $CMD'
+
+#echo "now copy the results to $six_ALL_CCFRWORK/datasets-custom/oscar/ from $six_ALL_CCFRSCRATCH/datasets/oscar-small/meg-gpt2"


### PR DESCRIPTION
I can't run on JZ, but for a concrete example, I think a script like the one in this PR could be used with the new ``preprocess_data_dist.py`` script.  This requires the JSON support added in PR https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/60

To process a JSON file, the script first generates an "index" that records the starting byte offset and length of each line in the source JSON file.  That index file is stored beside the source JSON file to be reused in future runs.  The index enables quick random access to the (variable-length) lines in the JSON file.

In the example SLURM script in this PR, for the source file:
```
$six_ALL_CCFRSCRATCH/datasets/oscar-small/oscar-en-shuffled-p1.jsonl
```
the ``preprocess_data_dist.py`` script will create the following files as a result of indexing the source JSON file:
```
$six_ALL_CCFRSCRATCH/datasets/oscar-small/oscar-en-shuffled-p1.jsonl.idx (persists after first run)
$six_ALL_CCFRSCRATCH/datasets/oscar-small/oscar-en-shuffled-p1.jsonl.idxtmp (created and deleted during run)
```