### PR TITLE
Update `.bashrc` to change what is executed for non-interactive shell

### DIFF
--- a/jz/envs/README.md
+++ b/jz/envs/README.md
@@ -26,6 +26,9 @@ Use `idracct six` to see which username belongs to which real person.
 Add this to your `~/.bashrc` and run `bash` for the changes to take effect.
 
 ```
+# ~/.bashrc: executed by bash(1) for non-login shells.
+[[ $- != *i* ]] && return
+
 # Log in with correct group - relevant to all users as we have multiple groups we belong to
 if [[ $(id -gn) != "six" ]]
 then


### PR DESCRIPTION
As discussed on Slack, I propose here to add a command to the top of `.bashrc` so that commands like `rsync` can be executed. Without this check to know if we are in interactive mode or not, when we were not in interactive mode the command remains blocked due to prints (generated by `module load`).