### PR TITLE
Update README.md

### DIFF
--- a/train/tr1-13B-base/README.md
+++ b/train/tr1-13B-base/README.md
@@ -637,7 +637,7 @@ Prepare the target dir:
 cd tr1-13B-checkpoints
 
 
-transformers-cli lfs-enable-largefiles .
+huggingface-cli lfs-enable-largefiles .
 
 git config --unset user.email
 ~/prod/code/bigscience/tools/hub-sync.py --repo-path . --patterns '*bogus*'


### PR DESCRIPTION
`transformers-cli` used to leave a warning to use `huggingface-cli`, and atm fails for me with `pkg_resources.DistributionNotFound: The 'huggingface-hub>=0.0.17' distribution was not found and is required by transformers`