### PR TITLE
Merge datasets according to lang

### DIFF
--- a/data/catalogue/catalogue-jsonl-to-meg-ds.slurm
+++ b/data/catalogue/catalogue-jsonl-to-meg-ds.slurm
@@ -18,7 +18,7 @@ conda activate thomas_data_tooling
 
 # Get dataset names
 
-CATALOGUE_DATA_REPO=$WORK/code/big_science/catalogue_data
+CATALOGUE_DATA_REPO=$six_ALL_CCFRWORK/code/catalogue_data
 pushd $CATALOGUE_DATA_REPO
 
 DATASET_PATH=$(python get_dataset_path.py --dataset-ratios-file training_dataset_ratios.json --index $SLURM_ARRAY_TASK_ID)

--- a/data/catalogue/load_ratios_meg_ds_format.py
+++ b/data/catalogue/load_ratios_meg_ds_format.py
@@ -43,7 +43,7 @@ def main():
 
     # TODO: you can add some extra dataset names for validation/test
     with open(args.output_meg_ds_ratio_file, "w") as fi:
-        fi.write(f"\"{args.split}: " + ", ".join(list_string) + "\"")
+        fi.write(f"\"{args.split}: " + ", ".join(list_string) + "\"\n")
 
 if __name__ == "__main__":
     main()

--- a/data/catalogue/load_ratios_meg_ds_format.py
+++ b/data/catalogue/load_ratios_meg_ds_format.py
@@ -5,7 +5,7 @@ import json
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--dataset_ratios_path",
+        "--dataset-ratios-path",
         type=str,
         required=True,
         help="path to JSON file containing input dataset ratios. Values ares dictionary: {'dataset_path': str, 'ratio': float}",
@@ -13,7 +13,12 @@ def get_args():
     parser.add_argument(
         "--split",
         choices=["train", "valid", "test"]
-
+    )
+    parser.add_argument(
+        "--output-meg-ds-ratio-file",
+        type=str,
+        required=True,
+        help="path to output the language ratio file",
     )
     return parser.parse_args()
 
@@ -37,8 +42,8 @@ def main():
         list_string.append(elt_string)
 
     # TODO: you can add some extra dataset names for validation/test
-    print(f"\"{args.split}: " + ", ".join(list_string) + "\"")
-
+    with open(args.output_meg_ds_ratio_file, "r") as fi:
+        fi.write(f"\"{args.split}: " + ", ".join(list_string) + "\"")
 
 if __name__ == "__main__":
     main()

--- a/data/catalogue/load_ratios_meg_ds_format.py
+++ b/data/catalogue/load_ratios_meg_ds_format.py
@@ -42,7 +42,7 @@ def main():
         list_string.append(elt_string)
 
     # TODO: you can add some extra dataset names for validation/test
-    with open(args.output_meg_ds_ratio_file, "r") as fi:
+    with open(args.output_meg_ds_ratio_file, "w") as fi:
         fi.write(f"\"{args.split}: " + ", ".join(list_string) + "\"")
 
 if __name__ == "__main__":

--- a/data/catalogue/merge_dataset_per_language.py
+++ b/data/catalogue/merge_dataset_per_language.py
@@ -68,7 +68,7 @@ def main():
         for lang, datasets in datasets_per_language.items()
     ]
 
-    with open(args.output_ratio_file, "r") as fi:
+    with open(args.output_ratio_file, "w") as fi:
         json.dump(language_ds_ratios, fi, indent=2)
 
 if __name__ == "__main__":

--- a/data/catalogue/merge_dataset_per_language.py
+++ b/data/catalogue/merge_dataset_per_language.py
@@ -30,11 +30,6 @@ def get_args():
     )
     return parser.parse_args()
 
-TOKEN_RANGES={
-    "train": "0:0.949",
-    "valid": "0.949:0.999",
-    "test": "0.999:1.0"
-}
 
 def main():
     args = get_args()

--- a/data/catalogue/merge_dataset_per_language.py
+++ b/data/catalogue/merge_dataset_per_language.py
@@ -1,0 +1,75 @@
+import argparse
+import json
+from collections import defaultdict
+
+import regex as re
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dataset-ratios-path",
+        type=str,
+        required=True,
+        help="path to JSON file containing input dataset ratios. Values ares dictionary: {'dataset_path': str, 'ratio': float}",
+    )
+    parser.add_argument(
+        "--split",
+        choices=["train", "valid", "test"]
+    )
+    parser.add_argument(
+        "--meg-ds-dataset-prefix",
+        type=str,
+        required=True,
+        help="We add `lang` to that prefix in order to designate the path for a languages specific dataset."
+    )
+    parser.add_argument(
+        "--output-ratio-file",
+        type=str,
+        required=True,
+        help="path to output the language ratio file",
+    )
+    return parser.parse_args()
+
+TOKEN_RANGES={
+    "train": "0:0.949",
+    "valid": "0.949:0.999",
+    "test": "0.999:1.0"
+}
+
+def main():
+    args = get_args()
+
+    # load training datasets
+    with open(args.dataset_ratios_path, "r") as fi:
+        ds_ratios = json.load(fi)
+
+    # get all individual languages
+    r = re.compile(r"^.*bigscience-catalogue-lm-data/lm_([^_]+)_.*$")
+    datasets_per_language = defaultdict(lambda: [])
+    for ds_ratio in ds_ratios:
+        candidate_lang = r.match(ds_ratio["dataset_path"]).group(1)
+        if candidate_lang == "hi":
+            ds_ratio["lang"] = "indic-hi"
+        else:
+            ds_ratio["lang"] = candidate_lang
+        datasets_per_language[ds_ratio["lang"]].append(ds_ratio)
+
+    # save ratio result into a file (in json format, you can use `load_ratios_meg_ds_format` for get the meg_ds format)
+    language_ds_ratios = [
+        {
+            "ratio": sum([elt["ratio"] for elt in datasets]),
+            "dataset_path": args.med_ds_dataset_prefix.format(lang=lang),
+            # Additional field to store in case we want to know what's in there.
+            "original_datasets": [
+                dataset["dataset_path"]
+                for dataset in datasets
+            ]
+        }
+        for lang, datasets in datasets_per_language.items()
+    ]
+
+    with open(args.output_ratio_file, "r") as fi:
+        json.dump(language_ds_ratios, fi, indent=2)
+
+if __name__ == "__main__":
+    main()

--- a/data/catalogue/merge_dataset_per_language.py
+++ b/data/catalogue/merge_dataset_per_language.py
@@ -52,7 +52,13 @@ def main():
             ds_ratio["lang"] = "indic-hi"
         else:
             ds_ratio["lang"] = candidate_lang
-        datasets_per_language[ds_ratio["lang"]].append(ds_ratio)
+
+        merged_language = ds_ratio["lang"].split("-")[0]
+        # Merge zh languages
+        if candidate_lang in ["zhs", "zht"]:
+            merged_language = "zh"
+
+        datasets_per_language[merged_language].append(ds_ratio)
 
     # save ratio result into a file (in json format, you can use `load_ratios_meg_ds_format` for get the meg_ds format)
     language_ds_ratios = [

--- a/data/catalogue/merge_dataset_per_language.py
+++ b/data/catalogue/merge_dataset_per_language.py
@@ -58,7 +58,7 @@ def main():
     language_ds_ratios = [
         {
             "ratio": sum([elt["ratio"] for elt in datasets]),
-            "dataset_path": args.med_ds_dataset_prefix.format(lang=lang),
+            "dataset_path": args.meg_ds_dataset_prefix.format(lang=lang),
             # Additional field to store in case we want to know what's in there.
             "original_datasets": [
                 dataset["dataset_path"]

--- a/data/catalogue/merge_dataset_per_languages.slurm
+++ b/data/catalogue/merge_dataset_per_languages.slurm
@@ -40,9 +40,13 @@ pushd $MEG_DS_REPO
 
 readarray -t MERGE_ARGUMENTS < <(python -c "
 import json
+from pathlib import Path
 
 with open(\"$LANGUAGE_RATIOS_PATH\", \"r\") as fi:
     data = json.load(fi)
+
+for elt in data:
+    Path(elt['dataset_path']).parent.mkdir(parents=True)
 
 print('\n'.join([f\"--datasets {' '.join(elt['original_datasets'])} --output-prefix {elt['dataset_path']}\" for elt in data]))
 ")
@@ -51,6 +55,6 @@ echo $MERGE_ARGUMENTS
 
 for MERGE_ARGUMENT in "${MERGE_ARGUMENTS[@]}"
 do
-	/usr/bin/time -v python tools/merge_preprocessed_data.py \
+	/usr/bin/time -v python -m tools.merge_preprocessed_data \
         $MERGE_ARGUMENT
 done

--- a/data/catalogue/merge_dataset_per_languages.slurm
+++ b/data/catalogue/merge_dataset_per_languages.slurm
@@ -30,12 +30,12 @@ mkdir -p $(dirname $MEG_DS_DATASET_PREFIX)
 python $BIGSCIENCE_REPO/data/catalogue/merge_dataset_per_language.py \
     --dataset-ratios-path $BIGSCIENCE_REPO/data/catalogue/training_dataset_ratios_batch_$BATCH_ID.json \
     --split train \
-    --meg-ds-dataset-prefix MEG_DS_DATASET_PREFIX \
+    --meg-ds-dataset-prefix $MEG_DS_DATASET_PREFIX \
     --output-ratio-file $LANGUAGE_RATIOS_PATH
 
 # ======= Generate merged files ======
 
-MEG_DS_REPO=$WORK/code/big_science/Megatron-Deepspeed
+MEG_DS_REPO=$WORK/code/big_science/Megatron-DeepSpeed
 pushd $MEG_DS_REPO
 MERGE_ARGUMENTS=(
 python -c "

--- a/data/catalogue/merge_dataset_per_languages.slurm
+++ b/data/catalogue/merge_dataset_per_languages.slurm
@@ -38,7 +38,7 @@ python $BIGSCIENCE_REPO/data/catalogue/merge_dataset_per_language.py \
 MEG_DS_REPO=$WORK/code/big_science/Megatron-DeepSpeed
 pushd $MEG_DS_REPO
 MERGE_ARGUMENTS=(
-python -c "
+$(python -c "
 import json
 
 with open($LANGUAGE_RATIOS_PATH, 'r') as fi:
@@ -47,7 +47,7 @@ with open($LANGUAGE_RATIOS_PATH, 'r') as fi:
 print('\n'.join(
     [f\"--datasets {' '.join(elt['original_datasets'])} --output-prefix dataset['dataset_path']\" for lang, dataset in data.items()]
 ))
-"
+")
 )
 
 echo $MERGE_ARGUMENTS

--- a/data/catalogue/merge_dataset_per_languages.slurm
+++ b/data/catalogue/merge_dataset_per_languages.slurm
@@ -45,7 +45,7 @@ with open($LANGUAGE_RATIOS_PATH, 'r') as fi:
     data = json.load(fi)
 
 print('\n'.join(
-    [f\"--datasets {' '.join(elt['original_datasets'])} --output-prefix dataset['dataset_path']\" for lang, dataset in data.]
+    [f\"--datasets {' '.join(elt['original_datasets'])} --output-prefix dataset['dataset_path']\" for lang, dataset in data.items()]
 ))
 "
 )

--- a/data/catalogue/merge_dataset_per_languages.slurm
+++ b/data/catalogue/merge_dataset_per_languages.slurm
@@ -1,0 +1,80 @@
+#!/bin/bash
+#SBATCH --job-name=catalogue-jsonl-to-meg-ds # job name
+#SBATCH --ntasks=1                   # number of MP tasks
+#SBATCH --nodes=1
+#SBATCH --cpus-per-task=10           # number of cores per tasks
+#SBATCH --hint=nomultithread         # we get physical cores not logical
+#SBATCH --time=20:00:00             # maximum execution time (HH:MM:SS)
+#SBATCH --output=logs/merge-meg-ds/%x-%j.out          # output file name
+#SBATCH --account=six@cpu
+#SBATCH --partition=compil
+
+set -x -e
+
+source $six_ALL_CCFRWORK/start-prod
+# We need a specific installation of tokenizers so that it works with bytefallback
+conda activate thomas_data_tooling
+
+BATCH_ID=0
+TOKENIZER_NAME_OR_PATH=bigscience-catalogue-data-dev/byte-level-bpe-tokenizer-no-norm-250k-whitespace-and-eos-regex-alpha-v2-dedup-lines-articles
+
+# ======= Get dataset names ======
+
+CATALOGUE_DATA_REPO=$WORK/code/big_science/catalogue_data
+pushd $CATALOGUE_DATA_REPO
+
+DATASET_PATH=$(python get_dataset_path.py --dataset-ratios-file training_dataset_ratios.json --index $SLURM_ARRAY_TASK_ID)
+echo "Converting $DATASET_PATH to json"
+
+if [[ $DATASET_PATH == /gpfswork/rech/six/uty16tp/dataset/tokenization/* ]]
+then
+    if [[ $DATASET_PATH == */data ]]
+    then
+        DATASET_NAME=${DATASET_PATH:48:-5}
+    else
+        DATASET_NAME=${DATASET_PATH:48}
+    fi
+else
+    DATASET_NAME=$DATASET_PATH
+fi
+
+# ======= Generate language ratio file ======
+
+BIGSCIENCE_REPO=$WORK/code/big_science/bigscience
+
+LANGUAGE_RATIOS_PATH=$BIGSCIENCE_REPO/data/catalogue/training_dataset_ratios_batch_${BATCH_ID}_per_language.json
+MEG_DS_DATASET_PREFIX=$six_ALL_CCFRSCRATCH/bigscience-datasets/catalogue/meg-ds-per-lang/{lang}/"${TOKENIZER_NAME_OR_PATH//\//_}"_batch_${BATCH_ID}_text_document
+
+mkdir -p $(dirname $MEG_DS_DATASET_PREFIX)
+
+python $BIGSCIENCE_REPO/data/catalogue/merge_dataset_per_language.py \
+    --dataset-ratios-path $BIGSCIENCE_REPO/data/catalogue/training_dataset_ratios_batch_$BATCH_ID.json \
+    --split train \
+    --meg-ds-dataset-prefix MEG_DS_DATASET_PREFIX \
+    --output-ratio-file $LANGUAGE_RATIOS_PATH
+
+# ======= Generate merged files ======
+
+MEG_DS_REPO=$WORK/code/big_science/Megatron-Deepspeed
+pushd $MEG_DS_REPO
+MERGE_ARGUMENTS=(
+python -c "
+import json
+
+with open($LANGUAGE_RATIOS_PATH, 'r') as fi:
+    data = json.load(fi)
+
+print('\n'.join(
+    [f\"--datasets {' '.join(elt['original_datasets'])} --output-prefix dataset['dataset_path']\" for lang, dataset in data.]
+))
+"
+)
+
+echo $MERGE_ARGUMENTS
+
+for MERGE_ARGUMENT in "${MERGE_ARGUMENTS[@]}"
+do
+	/usr/bin/time -v python tools/merge_preprocessed_data.py \
+        $MERGE_ARGUMENT
+done
+

--- a/data/catalogue/merge_dataset_per_languages.slurm
+++ b/data/catalogue/merge_dataset_per_languages.slurm
@@ -45,7 +45,7 @@ with open('$LANGUAGE_RATIOS_PATH', 'r') as fi:
     data = json.load(fi)
 
 print('\n'.join(
-    [f\"--datasets {' '.join(elt['original_datasets'])} --output-prefix dataset['dataset_path']\" for lang, dataset in data.items()]
+    [f\"--datasets {' '.join(elt['original_datasets'])} --output-prefix dataset['dataset_path']\" for dataset in data]
 ))
 ")
 )

--- a/data/catalogue/merge_dataset_per_languages.slurm
+++ b/data/catalogue/merge_dataset_per_languages.slurm
@@ -46,7 +46,7 @@ with open(\"$LANGUAGE_RATIOS_PATH\", \"r\") as fi:
     data = json.load(fi)
 
 for elt in data:
-    Path(elt['dataset_path']).parent.mkdir(parents=True)
+    Path(elt['dataset_path']).parent.mkdir(parents=True, exist_ok=True)
 
 print('\n'.join([f\"--datasets {' '.join(elt['original_datasets'])} --output-prefix {elt['dataset_path']}\" for elt in data]))
 ")

--- a/data/catalogue/merge_dataset_per_languages.slurm
+++ b/data/catalogue/merge_dataset_per_languages.slurm
@@ -45,7 +45,7 @@ with open('$LANGUAGE_RATIOS_PATH', 'r') as fi:
     data = json.load(fi)
 
 print('\n'.join(
-    [f\"--datasets {' '.join(elt['original_datasets'])} --output-prefix dataset['dataset_path']\" for dataset in data]
+    [f\"--datasets {' '.join(elt['original_datasets'])} --output-prefix elt['dataset_path']\" for elt in data]
 ))
 ")
 )

--- a/data/catalogue/merge_dataset_per_languages.slurm
+++ b/data/catalogue/merge_dataset_per_languages.slurm
@@ -20,7 +20,7 @@ TOKENIZER_NAME_OR_PATH=bigscience-catalogue-data-dev/byte-level-bpe-tokenizer-no
 
 # ======= Generate language ratio file ======
 
-BIGSCIENCE_REPO=$WORK/code/big_science/bigscience
+BIGSCIENCE_REPO=$six_ALL_CCFRWORK/code/bigscience
 
 LANGUAGE_RATIOS_PATH=$BIGSCIENCE_REPO/data/catalogue/training_dataset_ratios_batch_${BATCH_ID}_per_language.json
 MEG_DS_DATASET_PREFIX=$six_ALL_CCFRSCRATCH/bigscience-datasets/catalogue/meg-ds-per-lang/{lang}/"${TOKENIZER_NAME_OR_PATH//\//_}"_batch_${BATCH_ID}_text_document
@@ -35,7 +35,7 @@ python $BIGSCIENCE_REPO/data/catalogue/merge_dataset_per_language.py \
 
 # ======= Generate merged files ======
 
-MEG_DS_REPO=$WORK/code/big_science/Megatron-DeepSpeed
+MEG_DS_REPO=$six_ALL_CCFRWORK/code/Megatron-DeepSpeed
 pushd $MEG_DS_REPO
 
 readarray -t MERGE_ARGUMENTS < <(python -c "

--- a/data/catalogue/merge_dataset_per_languages.slurm
+++ b/data/catalogue/merge_dataset_per_languages.slurm
@@ -41,7 +41,7 @@ MERGE_ARGUMENTS=(
 $(python -c "
 import json
 
-with open($LANGUAGE_RATIOS_PATH, 'r') as fi:
+with open('$LANGUAGE_RATIOS_PATH', 'r') as fi:
     data = json.load(fi)
 
 print('\n'.join(

--- a/data/catalogue/merge_dataset_per_languages.slurm
+++ b/data/catalogue/merge_dataset_per_languages.slurm
@@ -18,26 +18,6 @@ conda activate thomas_data_tooling
 BATCH_ID=0
 TOKENIZER_NAME_OR_PATH=bigscience-catalogue-data-dev/byte-level-bpe-tokenizer-no-norm-250k-whitespace-and-eos-regex-alpha-v2-dedup-lines-articles
 
-# ======= Get dataset names ======
-
-CATALOGUE_DATA_REPO=$WORK/code/big_science/catalogue_data
-pushd $CATALOGUE_DATA_REPO
-
-DATASET_PATH=$(python get_dataset_path.py --dataset-ratios-file training_dataset_ratios.json --index $SLURM_ARRAY_TASK_ID)
-echo "Converting $DATASET_PATH to json"
-
-if [[ $DATASET_PATH == /gpfswork/rech/six/uty16tp/dataset/tokenization/* ]]
-then
-    if [[ $DATASET_PATH == */data ]]
-    then
-        DATASET_NAME=${DATASET_PATH:48:-5}
-    else
-        DATASET_NAME=${DATASET_PATH:48}
-    fi
-else
-    DATASET_NAME=$DATASET_PATH
-fi
-
 # ======= Generate language ratio file ======
 
 BIGSCIENCE_REPO=$WORK/code/big_science/bigscience

--- a/data/catalogue/merge_dataset_per_languages.slurm
+++ b/data/catalogue/merge_dataset_per_languages.slurm
@@ -37,18 +37,15 @@ python $BIGSCIENCE_REPO/data/catalogue/merge_dataset_per_language.py \
 
 MEG_DS_REPO=$WORK/code/big_science/Megatron-DeepSpeed
 pushd $MEG_DS_REPO
-MERGE_ARGUMENTS=(
-$(python -c "
+
+readarray -t MERGE_ARGUMENTS < <(python -c "
 import json
 
-with open('$LANGUAGE_RATIOS_PATH', 'r') as fi:
+with open(\"$LANGUAGE_RATIOS_PATH\", \"r\") as fi:
     data = json.load(fi)
 
-print('\n'.join(
-    [f\"--datasets {' '.join(elt['original_datasets'])} --output-prefix elt['dataset_path']\" for elt in data]
-))
+print('\n'.join([f\"--datasets {' '.join(elt['original_datasets'])} --output-prefix {elt['dataset_path']}\" for elt in data]))
 ")
-)
 
 echo $MERGE_ARGUMENTS
 
@@ -57,4 +54,3 @@ do
 	/usr/bin/time -v python tools/merge_preprocessed_data.py \
         $MERGE_ARGUMENT
 done
-

--- a/data/catalogue/training_dataset_ratios_batch_0.json
+++ b/data/catalogue/training_dataset_ratios_batch_0.json
@@ -1300,7 +1300,7 @@
     "ratio": 0.0001421613075
   },
   {
-    "dataset_path": "/gpfswork/rech/six/commun/bigscience-training/meg-ds/bigscience-catalogue-lm-data/lm_hi_pseudocrawl-filtered_515_www_aajtak_in/meg_ds_bigscience-catalogue-data-dev_byte-level-bpe-tokenizer-no-norm-250k-whitespace-and-eos-regex-alpha-v2-dedup-lines-articles_shard_0_8_text_document",
+    "dataset_path": "/gpfswork/rech/six/commun/bigscience-training/meg-ds/bigscience-catalogue-lm-data/lm_indic-hi_pseudocrawl-filtered_515_www_aajtak_in/meg_ds_bigscience-catalogue-data-dev_byte-level-bpe-tokenizer-no-norm-250k-whitespace-and-eos-regex-alpha-v2-dedup-lines-articles_shard_0_8_text_document",
     "ratio": 0.0006125
   },
   {
@@ -1312,7 +1312,7 @@
     "ratio": 0.0008846629225
   },
   {
-    "dataset_path": "/gpfswork/rech/six/commun/bigscience-training/meg-ds/bigscience-catalogue-lm-data/lm_hi_pseudocrawl-filtered_667_www_bhaskar_com/meg_ds_bigscience-catalogue-data-dev_byte-level-bpe-tokenizer-no-norm-250k-whitespace-and-eos-regex-alpha-v2-dedup-lines-articles_shard_0_8_text_document",
+    "dataset_path": "/gpfswork/rech/six/commun/bigscience-training/meg-ds/bigscience-catalogue-lm-data/lm_indic-hi_pseudocrawl-filtered_667_www_bhaskar_com/meg_ds_bigscience-catalogue-data-dev_byte-level-bpe-tokenizer-no-norm-250k-whitespace-and-eos-regex-alpha-v2-dedup-lines-articles_shard_0_8_text_document",
     "ratio": 0.0018125
   },
   {


### PR DESCRIPTION
Some things to note when merging datasets within a language:
 - all datasets are merged with their "main language". For example: "indic-hi" becomes "indic".
 - once merged there is no possible way to upsample a sub language, ie their proportion is stuck to the difference in dataset sizes.
 
 cc @stas00 as I changed the API to the load_ratio code in case we still use it.