### PR TITLE
set the size of the Embedding matrix to `250880` - a multiple of `8 * 128` and that keeps 200 unused tokens

### DIFF
--- a/train/tr11-200B-ml/tr11-200B-ml.slurm
+++ b/train/tr11-200B-ml/tr11-200B-ml.slurm
@@ -128,6 +128,7 @@ GPT_ARGS=" \
     --checkpoint-activations \
     --abort-on-unmet-fused-kernel-constraints \
     --kill-switch-path $KILL_SWITCH_PATH \
+    --make-vocab-size-divisible-by 1024 \
     $OPTIMIZER_ARGS \
     $EXIT_OPTS \
     "

--- a/train/tr11-200B-ml/tr11-200B-ml.slurm
+++ b/train/tr11-200B-ml/tr11-200B-ml.slurm
@@ -128,7 +128,7 @@ GPT_ARGS=" \
     --checkpoint-activations \
     --abort-on-unmet-fused-kernel-constraints \
     --kill-switch-path $KILL_SWITCH_PATH \
-    --make-vocab-size-divisible-by 1024 \
+    --pad-vocab-size-to 250880 \
     $OPTIMIZER_ARGS \
     $EXIT_OPTS \
     "


### PR DESCRIPTION
Following a discussion with @thomasw21 , we realized that we would most certainly have to add an argument to the configuration file of the large training so that the dimension corresponding to the size of the vocabulary of the Embedding matrix is the desired one. 

In particular, we would like to add 200 spare tokens to our tokenizer (for example for the special tokens of PII). These unused tokens are currently not included in our tokenizer, so it is necessary to "add" them in Megatron-deepspeed by specifying the mutltiple we want for the dimension of the vocabulary of the embedding matrix.

Our tokenizer has a vocabulary of size `250680`, so if we add 200 tokens, the vocabulary reached is of size `250880` which is equal to `8*128*245`. Hence the proposed `1024` argument.


I've go through the code base to check the behavior of this arg but ideally, I would have liked to check the dimensions of the components of the model created with these arguments, but I don't see an easy way to do that. Do you know of one?