### PR TITLE
Replaced obsolete six@gpu with six@v100

### DIFF
--- a/train/arch-and-scaling-template.slurm
+++ b/train/arch-and-scaling-template.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr1-13B-base/tr1-13B-round1.slurm
+++ b/train/tr1-13B-base/tr1-13B-round1.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr1-13B-base/tr1-13B-short.slurm
+++ b/train/tr1-13B-base/tr1-13B-short.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 
 
@@ -20,7 +20,7 @@
 # Change to NNODES=1 if needed
 #
 # to allocate (change to 2 for NNODES=2)
-# salloc --constraint=v100-32g --account=six@gpu --nodes=1 --ntasks=1 --cpus-per-task=40 --gres=gpu:4 --hint=nomultithread --time=6:00:00 bash
+# salloc --constraint=v100-32g --account=six@v100 --nodes=1 --ntasks=1 --cpus-per-task=40 --gres=gpu:4 --hint=nomultithread --time=6:00:00 bash
 
 source $six_ALL_CCFRWORK/code/tr1-13B/bigscience/train/tr1-13B-base/start-tr1-13B
 

--- a/train/tr10-13B-ml/README.md
+++ b/train/tr10-13B-ml/README.md
@@ -7,7 +7,7 @@
 To interactively tune up the setup:
 
 ```
-salloc --constraint=v100-32g --account=six@gpu --nodes=4 --ntasks=4 --cpus-per-task=40 --gres=gpu:4 --hint=nomultithread --time=120 bash --rcfile $six_ALL_CCFRWORK/code/tr10-13B/bigscience/train/tr10-13B-ml/start-tr10-13B
+salloc --constraint=v100-32g --account=six@v100 --nodes=4 --ntasks=4 --cpus-per-task=40 --gres=gpu:4 --hint=nomultithread --time=120 bash --rcfile $six_ALL_CCFRWORK/code/tr10-13B/bigscience/train/tr10-13B-ml/start-tr10-13B
 ```
 
 

--- a/train/tr10-13B-ml/tr10-13B.slurm
+++ b/train/tr10-13B-ml/tr10-13B.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr11-176B-ml/smaller_models/tr11b-1B3-ml.slurm
+++ b/train/tr11-176B-ml/smaller_models/tr11b-1B3-ml.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00             # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr11-176B-ml/smaller_models/tr11c-2B5-ml.slurm
+++ b/train/tr11-176B-ml/smaller_models/tr11c-2B5-ml.slurm
@@ -6,9 +6,9 @@
 #SBATCH --cpus-per-task=40           # number of cores per tasks
 #SBATCH --hint=nomultithread         # we get physical cores not logical
 #SBATCH --gres=gpu:4                 # number of gpus
-#SBATCH --time 00:30:00             # maximum execution time (HH:MM:SS)
+#SBATCH --time 20:00:00             # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr11-176B-ml/smaller_models/tr11d-760M-ml.slurm
+++ b/train/tr11-176B-ml/smaller_models/tr11d-760M-ml.slurm
@@ -9,7 +9,7 @@
 #SBATCH -C v100-32g
 #SBATCH --time 20:00:00             # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr11-176B-ml/smaller_models/tr11e-350M-ml.slurm
+++ b/train/tr11-176B-ml/smaller_models/tr11e-350M-ml.slurm
@@ -9,7 +9,7 @@
 #SBATCH -C v100-32g
 #SBATCH --time 20:00:00             # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 
@@ -104,7 +104,7 @@ GPT_ARGS=" \
     --seq-length $SEQ_LEN \
     --max-position-embeddings $SEQ_LEN \
     --micro-batch-size $MICRO_BATCH_SIZE \
-    --rampup-batch-size 192 16 9_765_625 \
+    --rampup-batch-size 192 32 9_765_625 \
     --global-batch-size $GLOBAL_BATCH_SIZE \
     --train-samples $TRAIN_SAMPLES \
     --tokenizer-type PretrainedFromHF \

--- a/train/tr11-176B-ml/smaller_models/tr11f-6B3-ml.slurm
+++ b/train/tr11-176B-ml/smaller_models/tr11f-6B3-ml.slurm
@@ -6,9 +6,10 @@
 #SBATCH --cpus-per-task=40           # number of cores per tasks
 #SBATCH --hint=nomultithread         # we get physical cores not logical
 #SBATCH --gres=gpu:4                 # number of gpus
-#SBATCH --time 00:30:00             # maximum execution time (HH:MM:SS)
+#SBATCH -C v100-32g
+#SBATCH --time 20:00:00             # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr12-1B3-oscar/tr12a-1B3-oscar-en-filtered.slurm
+++ b/train/tr12-1B3-oscar/tr12a-1B3-oscar-en-filtered.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%a-%j.out        # output file name
 #SBATCH --error=%x-%a-%j.out         # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 #SBATCH --mail-type=ALL
 #SBATCH --mail-user=hugo@huggingface.co
 

--- a/train/tr12-1B3-oscar/tr12b-1B3-oscar-en-filtered-dedup.slurm
+++ b/train/tr12-1B3-oscar/tr12b-1B3-oscar-en-filtered-dedup.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%a-%j.out        # output file name
 #SBATCH --error=%x-%a-%j.out         # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 #SBATCH --mail-type=ALL
 #SBATCH --mail-user=hugo@huggingface.co
 

--- a/train/tr12-1B3-oscar/tr12c-1B3-oscar-en-overfiltered.slurm
+++ b/train/tr12-1B3-oscar/tr12c-1B3-oscar-en-overfiltered.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%a-%j.out        # output file name
 #SBATCH --error=%x-%a-%j.out         # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 #SBATCH --mail-type=ALL
 #SBATCH --mail-user=hugo@huggingface.co
 

--- a/train/tr3-1B3-baseline/tr3-1B3-modeling-baseline.slurm
+++ b/train/tr3-1B3-baseline/tr3-1B3-modeling-baseline.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3b-760M.slurm
+++ b/train/tr3-1B3-baseline/tr3b-760M.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3c-350M.slurm
+++ b/train/tr3-1B3-baseline/tr3c-350M.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3d-1B3-more-warmup.slurm
+++ b/train/tr3-1B3-baseline/tr3d-1B3-more-warmup.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3d-1B3-oscar-training2.slurm
+++ b/train/tr3-1B3-baseline/tr3d-1B3-oscar-training2.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3e-1B3-c4-training2.slurm
+++ b/train/tr3-1B3-baseline/tr3e-1B3-c4-training2.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3e-1B3-diagnostic1-warmup-c4.slurm
+++ b/train/tr3-1B3-baseline/tr3e-1B3-diagnostic1-warmup-c4.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3f-1B3-diagnostic2-low-warmup-oscar.slurm
+++ b/train/tr3-1B3-baseline/tr3f-1B3-diagnostic2-low-warmup-oscar.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3g-760M-v2.slurm
+++ b/train/tr3-1B3-baseline/tr3g-760M-v2.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3h-350M-v2.slurm
+++ b/train/tr3-1B3-baseline/tr3h-350M-v2.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3i-125M-v2.slurm
+++ b/train/tr3-1B3-baseline/tr3i-125M-v2.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3j-760M-pile.slurm
+++ b/train/tr3-1B3-baseline/tr3j-760M-pile.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3k-350M-pile.slurm
+++ b/train/tr3-1B3-baseline/tr3k-350M-pile.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3l-125M-pile.slurm
+++ b/train/tr3-1B3-baseline/tr3l-125M-pile.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3m-1B3-emb-norm-pile-optim-reset.slurm
+++ b/train/tr3-1B3-baseline/tr3m-1B3-emb-norm-pile-optim-reset.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 
 set -x -e

--- a/train/tr3-1B3-baseline/tr3m-1B3-emb-norm-pile.slurm
+++ b/train/tr3-1B3-baseline/tr3m-1B3-emb-norm-pile.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 
 set -x -e

--- a/train/tr3-1B3-baseline/tr3m-1B3-pile.slurm
+++ b/train/tr3-1B3-baseline/tr3m-1B3-pile.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr3-1B3-baseline/tr3n-1B3-pile-fancy.slurm
+++ b/train/tr3-1B3-baseline/tr3n-1B3-pile-fancy.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%a-%j.out        # output file name
 #SBATCH --error=%x-%a-%j.out         # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 #SBATCH --mail-type=ALL
 #SBATCH --mail-user=victor@huggingface.co
 

--- a/train/tr3-1B3-baseline/tr3o-1B3-pile-no-dropout.slurm
+++ b/train/tr3-1B3-baseline/tr3o-1B3-pile-no-dropout.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%a-%j.out        # output file name
 #SBATCH --error=%x-%a-%j.out         # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 #SBATCH --mail-type=ALL
 #SBATCH --mail-user=victor@huggingface.co
 

--- a/train/tr4-1B3-rotary/tr4-1B3-modeling-rotary.slurm
+++ b/train/tr4-1B3-rotary/tr4-1B3-modeling-rotary.slurm
@@ -7,7 +7,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 #SBATCH --array=1-10%1
 
 set -x -e

--- a/train/tr4-1B3-rotary/tr4b-350M-modeling-rotary.slurm
+++ b/train/tr4-1B3-rotary/tr4b-350M-modeling-rotary.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 # This is compared with tr3h-350M-v2.slurm
 

--- a/train/tr4-1B3-rotary/tr4c-1B3-oscar-modeling-rotary.slurm
+++ b/train/tr4-1B3-rotary/tr4c-1B3-oscar-modeling-rotary.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out          # output file name
 #SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err           # error file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr5-1B3-multilingual/mc4/tr5-1B3-modeling-multilingual.slurm
+++ b/train/tr5-1B3-multilingual/mc4/tr5-1B3-modeling-multilingual.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
 #SBATCH --error=logs/%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 #SBATCH --array=1-10%1
 
 set -x -e

--- a/train/tr5-1B3-multilingual/oscar/tr5a-1B3-multilingual-mt5tok.slurm
+++ b/train/tr5-1B3-multilingual/oscar/tr5a-1B3-multilingual-mt5tok.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr5-1B3-multilingual/oscar/tr5a-bnb-1B3-multilingual-mt5tok.slurm
+++ b/train/tr5-1B3-multilingual/oscar/tr5a-bnb-1B3-multilingual-mt5tok.slurm
@@ -10,7 +10,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
 #SBATCH --error=%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr5-1B3-multilingual/oscar/tr5b-1B3-multilingual-alpha.slurm
+++ b/train/tr5-1B3-multilingual/oscar/tr5b-1B3-multilingual-alpha.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr5-1B3-multilingual/oscar/tr5c-1B3-multilingual-alpha-alibi.slurm
+++ b/train/tr5-1B3-multilingual/oscar/tr5c-1B3-multilingual-alpha-alibi.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr5-1B3-multilingual/oscar/tr5d-1B3-multilingual-equal-alibi.slurm
+++ b/train/tr5-1B3-multilingual/oscar/tr5d-1B3-multilingual-equal-alibi.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr6-1B3-prefix-lm/tr6-1B3-modeling-prefix-lm-unbiased-loss.slurm
+++ b/train/tr6-1B3-prefix-lm/tr6-1B3-modeling-prefix-lm-unbiased-loss.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 # This is compared with tr3d-1B3-more-warmup.slurm
 

--- a/train/tr6-1B3-prefix-lm/tr6-1B3-modeling-prefix-lm.slurm
+++ b/train/tr6-1B3-prefix-lm/tr6-1B3-modeling-prefix-lm.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 # This is compared with tr3d-1B3-more-warmup.slurm
 

--- a/train/tr6-1B3-prefix-lm/tr6b-350M-modeling-prefix-lm-unbiased-loss.slurm
+++ b/train/tr6-1B3-prefix-lm/tr6b-350M-modeling-prefix-lm-unbiased-loss.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 # New experiment in order to check intuition behind previous failed experiment:
 # What we're exploring is the notion that the loss was originally biased to longer context (smaller prediction span)

--- a/train/tr6-1B3-prefix-lm/tr6b-350M-modeling-prefix-lm.slurm
+++ b/train/tr6-1B3-prefix-lm/tr6b-350M-modeling-prefix-lm.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr6-1B3-prefix-lm/tr6c-350M-reset-attention.slurm
+++ b/train/tr6-1B3-prefix-lm/tr6c-350M-reset-attention.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr6-1B3-prefix-lm/tr6d-350M-pile.slurm
+++ b/train/tr6-1B3-prefix-lm/tr6d-350M-pile.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr6-1B3-prefix-lm/tr6e-1B3-pile.slurm
+++ b/train/tr6-1B3-prefix-lm/tr6e-1B3-pile.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 # This is compared with tr3d-1B3-more-warmup.slurm
 

--- a/train/tr6-1B3-prefix-lm/tr6f-1B3-oscar-no-loss-on-targets-only.slurm
+++ b/train/tr6-1B3-prefix-lm/tr6f-1B3-oscar-no-loss-on-targets-only.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr7-alibi/tr7a-1B3-modeling-alibi.slurm
+++ b/train/tr7-alibi/tr7a-1B3-modeling-alibi.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out          # output file name
 #SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err           # error file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr7-alibi/tr7b-350M-modeling-alibi.slurm
+++ b/train/tr7-alibi/tr7b-350M-modeling-alibi.slurm
@@ -8,7 +8,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out          # output file name
 #SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err           # error file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr7-alibi/tr7b-check-with-train-script.slurm
+++ b/train/tr7-alibi/tr7b-check-with-train-script.slurm
@@ -8,7 +8,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out          # output file name
 #SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err           # error file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr7-alibi/tr7b-extrapolation-law.slurm
+++ b/train/tr7-alibi/tr7b-extrapolation-law.slurm
@@ -8,7 +8,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out          # output file name
 #SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err           # error file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr7-alibi/tr7c-1B3-modeling-alibi.slurm
+++ b/train/tr7-alibi/tr7c-1B3-modeling-alibi.slurm
@@ -10,7 +10,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out          # output file name
 #SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err           # error file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr7-alibi/tr7d-1B3-modeling-alibi.slurm
+++ b/train/tr7-alibi/tr7d-1B3-modeling-alibi.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out          # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr8-104B-wide/tr8-104B.slurm
+++ b/train/tr8-104B-wide/tr8-104B.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr8-104B-wide/tr8b-104B-pile.slurm
+++ b/train/tr8-104B-wide/tr8b-104B-pile.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr8b-104B/tr8b-104B-bnb.slurm
+++ b/train/tr8b-104B/tr8b-104B-bnb.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr8b-104B/tr8b-104B-cl-a100-16n.slurm
+++ b/train/tr8b-104B/tr8b-104B-cl-a100-16n.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:8                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr8b-104B/tr8b-104B-cl.slurm
+++ b/train/tr8b-104B/tr8b-104B-cl.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr8b-104B/tr8b-104B-emb-norm-64n.slurm
+++ b/train/tr8b-104B/tr8b-104B-emb-norm-64n.slurm
@@ -8,7 +8,7 @@
 #SBATCH --gres=gpu:4                 # number of gpus
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=%x-%j.out           # output file name
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr9-glu/tr9-1B3-modeling-swiglu.slurm
+++ b/train/tr9-glu/tr9-1B3-modeling-swiglu.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
 #SBATCH --error=logs/%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr9-glu/tr9b-350M-modeling-swiglu.slurm
+++ b/train/tr9-glu/tr9b-350M-modeling-swiglu.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
 #SBATCH --error=logs/%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 

--- a/train/tr9-glu/tr9c-1B3-swiglu-pile.slurm
+++ b/train/tr9-glu/tr9c-1B3-swiglu-pile.slurm
@@ -9,7 +9,7 @@
 #SBATCH --time 20:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=logs/%x-%j.out           # output file name
 #SBATCH --error=logs/%x-%j.out            # error file name (same to watch just one file)
-#SBATCH --account=six@gpu
+#SBATCH --account=six@v100
 
 set -x -e
 


### PR DESCRIPTION
Due to JZ changes, the `@gpu` flag in account choice will be phased out in favour of `@v100`. This PR updates the flag in the training scripts. I've checked once that nothing was broken, but if someone else wants to double check please do!