### PR TITLE
Update `google-cloud-sdk.md`

### DIFF
--- a/jz/tools/google-cloud-sdk.md
+++ b/jz/tools/google-cloud-sdk.md
@@ -1,6 +1,6 @@
 # google-cloud-sdk
 
-Installed in `$six_ALL_CCFRWORK/lib/google-cloud-sdk`
+Installed in `$six_ALL_CCFRWORK/lib/google-cloud-sdk` following the linux installation instructions [here](https://cloud.google.com/sdk/docs/install?hl=en).
 
 To activate add to your `~/.bashrc`:
 


### PR DESCRIPTION
[We have traced ](https://huggingface.slack.com/archives/C02UAKD75L7/p1653314161261859)that the google cloud sdk installed at `$six_ALL_CCFRWORK/lib/google-cloud-sdk` must have been installed following the linux instructions at `https://cloud.google.com/sdk/docs/install?hl=en` and therefore it would be good to indicate this on `google-cloud-sdk.md`.