### PR TITLE
Update FS watcher to check shared SCRATCH

### DIFF
--- a/tools/fs-watchdog.py
+++ b/tools/fs-watchdog.py
@@ -69,6 +69,7 @@ def run_cmd(cmd, check=True):
         ).stdout.strip()
     except subprocess.CalledProcessError as exc:
         raise EnvironmentError(exc.stderr)
+
     return git_status
 
 

--- a/tools/fs-watchdog.py
+++ b/tools/fs-watchdog.py
@@ -69,7 +69,6 @@ def run_cmd(cmd, check=True):
         ).stdout.strip()
     except subprocess.CalledProcessError as exc:
         raise EnvironmentError(exc.stderr)
-
     return git_status
 
 
@@ -135,14 +134,36 @@ def main():
             alerts.append(response)
             alerts.append("")
 
+    def analyse_shared_disk(partition_name, alert_bytes_threshold):
+        partition_name_2_disk = {
+            "SCRATCH": "gpfsssd",
+            "WORK": "gpfsdswork",
+            "STORE": "gpfsdsstore"
+        }
+        cmd = "df"
+        response = run_cmd(cmd.split())
+        disk_metas = response.split("\n")
+        column_names = disk_metas[0].split()
+        disk_meta = [disk_meta_.split() for disk_meta_ in disk_metas if disk_meta_.startswith(partition_name_2_disk[partition_name])][0]
+        disk_meta = {column_name: value for column_name, value in zip(column_names, disk_meta)}
+
+        available_disk_left = int(disk_meta["Available"])
+        if available_disk_left < alert_bytes_threshold:
+            # default `df` counts uses 1024-byte units, and `1024 == 2 ** 10`
+            alerts.append(f"Shared {partition_name} has {available_disk_left/2**(40 - 10):.2f}TB left")
+            alerts.append("")
+
     # WORK and STORE partitions stats can be accessed much faster through `idrquota`, and it already
     # includes the quota info
     analyse_partition_idrquota(partition_name="WORK", partition_flag="-w", alert_bytes_threshold=0.85, alert_inodes_threshold=0.85)
     analyse_partition_idrquota(partition_name="STORE", partition_flag="-s", alert_bytes_threshold=0.85, alert_inodes_threshold=0.85)
 
-    # SCRATCH - check only bytes w/ a hard quota of 400TB - alert on lower threshold than other
-    # partitions due to it filling up at a faster rate (dumping huge checkpoints)
-    analyse_partition_bytes(partition_name="SCRATCH", partition_path="/gpfsssd/scratch/rech/six/", hard_limit_bytes=400*2**40, alert_bytes_threshold=0.75)
+    # # SCRATCH - check only bytes w/ a hard quota of 400TB - alert on lower threshold than other
+    # # partitions due to it filling up at a faster rate (dumping huge checkpoints)
+    # analyse_partition_bytes(partition_name="SCRATCH", partition_path="/gpfsssd/scratch/rech/six/", hard_limit_bytes=400*2**40, alert_bytes_threshold=0.75)
+    # Actually SCRATCH is shared with everyone and we should monitor the output of `df -h | grep gpfsssd`
+    # Check that there's still 40TB left
+    analyse_shared_disk("SCRATCH", 40 * 2 ** 40)
 
     # WORKFS - check both bytes and inodes w/ hard quotas of 2TB / 3M
     analyse_partition_bytes(partition_name="WORKFS", partition_path="/gpfsssd/worksf/projects/rech/six/", hard_limit_bytes=2*2**40, alert_bytes_threshold=0.85)


### PR DESCRIPTION
We noticed that the previous watcher doesn't matter as SCRATCH is completely shared, and so our training script would fail when the total SCRATCH was filled. So instead we use the result of `df` to check SCRATCH usage and email when it's lower than 40TB (To be ajusted)