### PR TITLE
[all_reduce_bench] Add barrier and deprecate torch.distributed.launch

### DIFF
--- a/experiments/bandwidth/all_reduce_bench.py
+++ b/experiments/bandwidth/all_reduce_bench.py
@@ -1,4 +1,4 @@
-# python -m torch.distributed.launch --nproc_per_node=2 all_reduce_bench.py
+# python -m torch.distributed.run --nproc_per_node=2 all_reduce_bench.py
 
 import argparse
 import fcntl
@@ -59,9 +59,7 @@ def init_processes(local_rank, fn, backend='nccl'):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--local_rank", type=int)
-    args = parser.parse_args()
-    rank = args.local_rank
+    rank = int(os.environ["LOCAL_RANK"])
     printflock("local_rank: %d" % rank)
     init_processes(local_rank=rank, fn=run)
+

--- a/experiments/bandwidth/all_reduce_bench.py
+++ b/experiments/bandwidth/all_reduce_bench.py
@@ -48,6 +48,7 @@ def run(local_rank):
     mat = torch.rand(N, M, dtype=torch.float32).cuda(local_rank)
 
     for i in range(TRIALS):
+        dist.barrier()
         if global_rank == 0:
             print(f"\n\n\n-----------trial-{i}----------------")
         timed_allreduce(mat, id)


### PR DESCRIPTION
Is there a reason why we're not using `dist.barrier()` between trials? I get more homogeneous results by doing so

<details>
  <summary>Before adding barrier</summary>

```
$ python -m torch.distributed.run --nproc_per_node=4 all_reduce_bench.py
WARNING:__main__:
*****************************************
Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
*****************************************
local_rank: 3
local_rank: 2
local_rank: 0
local_rank: 1
hf-dgx-01:0 data size: 4.0 GB
hf-dgx-01:3 data size: 4.0 GB
hf-dgx-01:1 data size: 4.0 GB
hf-dgx-01:2 data size: 4.0 GB



-----------trial-0----------------
ignore me 3
ignore me 3
ignore me 3
hf-dgx-01:2:
 duration: 0.8994 sec
 algo throughput: 71161407180.0733 bps, 71.1614 Gbps
 busbw: 53.3711  Gbps
hf-dgx-01:3:
 duration: 0.8849 sec
 algo throughput: 72327955237.7401 bps, 72.3280 Gbps
 busbw: 54.2460  Gbps
ignore me 3
hf-dgx-01:0:
 duration: 0.8800 sec
 algo throughput: 72725563376.4329 bps, 72.7256 Gbps
 busbw: 54.5442  Gbps



-----------trial-1----------------
hf-dgx-01:1:
 duration: 0.9218 sec
 algo throughput: 69426891984.9816 bps, 69.4269 Gbps
 busbw: 52.0702  Gbps
ignore me 12
hf-dgx-01:3:
 duration: 0.0307 sec
 algo throughput: 2081836007209.2905 bps, 2081.8360 Gbps
 busbw: 1561.3770  Gbps
ignore me 12
ignore me 12
ignore me 12
hf-dgx-01:0:
 duration: 0.0307 sec
 algo throughput: 2082258021670.7380 bps, 2082.2580 Gbps
 busbw: 1561.6935  Gbps



-----------trial-2----------------hf-dgx-01:2:

 duration: 0.0308 sec
 algo throughput: 2075263567908.9573 bps, 2075.2636 Gbps
 busbw: 1556.4477  Gbps
hf-dgx-01:1:
 duration: 0.0307 sec
 algo throughput: 2083767317953.0203 bps, 2083.7673 Gbps
 busbw: 1562.8255  Gbps
ignore me 51
hf-dgx-01:3:
 duration: 0.0307 sec
 algo throughput: 2083842764375.5391 bps, 2083.8428 Gbps
 busbw: 1562.8821  Gbps
ignore me 51
ignore me 51
ignore me 51
hf-dgx-01:1:
 duration: 0.0307 sec
 algo throughput: 2087059619656.6069 bps, 2087.0596 Gbps
 busbw: 1565.2947  Gbps
hf-dgx-01:2:
 duration: 0.0307 sec
 algo throughput: 2086356151114.7852 bps, 2086.3562 Gbps
 busbw: 1564.7671  Gbps
hf-dgx-01:0:
 duration: 0.0307 sec
 algo throughput: 2082214613785.4868 bps, 2082.2146 Gbps
 busbw: 1561.6610  Gbps



-----------trial-3----------------
ignore me 206
ignore me 206
hf-dgx-01:2:
 duration: 0.0305 sec
 algo throughput: 2095312143545.3420 bps, 2095.3121 Gbps
 busbw: 1571.4841  Gbps
hf-dgx-01:3:
 duration: 0.0306 sec
 algo throughput: 2088640763393.0701 bps, 2088.6408 Gbps
 busbw: 1566.4806  Gbps
ignore me 206
ignore me 206
hf-dgx-01:1:
 duration: 0.0306 sec
 algo throughput: 2088867480684.7439 bps, 2088.8675 Gbps
 busbw: 1566.6506  Gbps
hf-dgx-01:0:
 duration: 0.0306 sec
 algo throughput: 2091655277001.5515 bps, 2091.6553 Gbps
 busbw: 1568.7415  Gbps



-----------trial-4----------------
ignore me 824
ignore me 824
hf-dgx-01:0:
 duration: 0.0305 sec
 algo throughput: 2101785639415.8032 bps, 2101.7856 Gbps
 busbw: 1576.3392  Gbps
hf-dgx-01:3:
 duration: 0.0305 sec
 algo throughput: 2096366246513.6816 bps, 2096.3662 Gbps
 busbw: 1572.2747  Gbps
ignore me 824
ignore me 824
hf-dgx-01:2:
 duration: 0.0306 sec
 algo throughput: 2091404721789.9250 bps, 2091.4047 Gbps
 busbw: 1568.5535  Gbps
hf-dgx-01:1:
 duration: 0.0305 sec
 algo throughput: 2095226281923.4409 bps, 2095.2263 Gbps
 busbw: 1571.4197  Gbps
```
</details>



<details>
  <summary>After adding barrier</summary>

```
$ python -m torch.distributed.run --nproc_per_node=4 all_reduce_bench.py
WARNING:__main__:
*****************************************
Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
*****************************************
local_rank: 0
local_rank: 2
local_rank: 1
local_rank: 3
hf-dgx-01:2 data size: 4.0 GB
hf-dgx-01:3 data size: 4.0 GB
hf-dgx-01:0 data size: 4.0 GB
hf-dgx-01:1 data size: 4.0 GB



-----------trial-0----------------
ignore me 1
hf-dgx-01:3:
 duration: 0.0361 sec
 algo throughput: 1773958731241.2180 bps, 1773.9587 Gbps
 busbw: 1330.4690  Gbps
ignore me 1
ignore me 1
hf-dgx-01:2:
 duration: 0.0362 sec
 algo throughput: 1768443257192.5903 bps, 1768.4433 Gbps
 busbw: 1326.3324  Gbps
ignore me 1
hf-dgx-01:1:
 duration: 0.0362 sec
 algo throughput: 1767334975794.6304 bps, 1767.3350 Gbps
 busbw: 1325.5012  Gbps
hf-dgx-01:0:
 duration: 0.0363 sec
 algo throughput: 1764783914046.7673 bps, 1764.7839 Gbps
 busbw: 1323.5879  Gbps



-----------trial-1----------------
ignore me 6
hf-dgx-01:3:
 duration: 0.0359 sec
 algo throughput: 1781416294183.1287 bps, 1781.4163 Gbps
 busbw: 1336.0622  Gbps
ignore me 6
hf-dgx-01:2:
 duration: 0.0360 sec
 algo throughput: 1778027759850.8909 bps, 1778.0278 Gbps
 busbw: 1333.5208  Gbps
ignore me 6
ignore me 6
hf-dgx-01:0:
 duration: 0.0360 sec
 algo throughput: 1775757182891.7207 bps, 1775.7572 Gbps
 busbw: 1331.8179  Gbps
hf-dgx-01:1:
 duration: 0.0361 sec
 algo throughput: 1774613183570.5413 bps, 1774.6132 Gbps
 busbw: 1330.9599  Gbps



-----------trial-2----------------
ignore me 27
ignore me 27
hf-dgx-01:3:
 duration: 0.0359 sec
 algo throughput: 1781899788169.6045 bps, 1781.8998 Gbps
 busbw: 1336.4248  Gbps
hf-dgx-01:0:
 duration: 0.0359 sec
 algo throughput: 1781279243412.9880 bps, 1781.2792 Gbps
 busbw: 1335.9594  Gbps
ignore me 27
hf-dgx-01:2:
 duration: 0.0360 sec
 algo throughput: 1778631769742.2512 bps, 1778.6318 Gbps
 busbw: 1333.9738  Gbps
ignore me 27
hf-dgx-01:1:
 duration: 0.0360 sec
 algo throughput: 1776185684981.9719 bps, 1776.1857 Gbps
 busbw: 1332.1393  Gbps



-----------trial-3----------------
ignore me 110
hf-dgx-01:3:
 duration: 0.0360 sec
 algo throughput: 1779447339014.5920 bps, 1779.4473 Gbps
 busbw: 1334.5855  Gbps
ignore me 110
hf-dgx-01:2:
 duration: 0.0360 sec
 algo throughput: 1777159211506.3142 bps, 1777.1592 Gbps
 busbw: 1332.8694  Gbps
ignore me 110
hf-dgx-01:0:
 duration: 0.0360 sec
 algo throughput: 1775511401585.4724 bps, 1775.5114 Gbps
 busbw: 1331.6336  Gbps
ignore me 110
hf-dgx-01:1:
 duration: 0.0361 sec
 algo throughput: 1772944473907.7449 bps, 1772.9445 Gbps
 busbw: 1329.7084  Gbps



-----------trial-4----------------
ignore me 440
hf-dgx-01:3:
 duration: 0.0360 sec
 algo throughput: 1778881869385.0701 bps, 1778.8819 Gbps
 busbw: 1334.1614  Gbps
ignore me 440
hf-dgx-01:2:
 duration: 0.0360 sec
 algo throughput: 1775874660747.7285 bps, 1775.8747 Gbps
 busbw: 1331.9060  Gbps
ignore me 440
ignore me 440
hf-dgx-01:1:
 duration: 0.0361 sec
 algo throughput: 1773335283948.1846 bps, 1773.3353 Gbps
 busbw: 1330.0015  Gbps
hf-dgx-01:0:
 duration: 0.0361 sec
 algo throughput: 1773109295862.0264 bps, 1773.1093 Gbps
 busbw: 1329.8320  Gbps
```
</details>

(Ran on DGX)

cc @stas00 
